### PR TITLE
Make read-me match the package.json description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # imba-router
-Experimental router for Imba
+Official router for Imba


### PR DESCRIPTION
"Experimental router for imba" was confusing when npm says it's the "official" router.